### PR TITLE
Update to use PyBuilder's new module name.

### DIFF
--- a/build.py
+++ b/build.py
@@ -18,7 +18,7 @@
     built with pybuilder.
 """
 
-from pythonbuilder.core import use_plugin, init, Author
+from pybuilder.core import use_plugin, init, Author
 
 use_plugin('filter_resources')
 


### PR DESCRIPTION
Apparently PyBuilder renamed their module from `pythonbuilder` to `pybuilder` since the last time this repo was updated.
